### PR TITLE
Strongly typed Role

### DIFF
--- a/Sources/OpenAIKit/Chat/Chat.swift
+++ b/Sources/OpenAIKit/Chat/Chat.swift
@@ -39,6 +39,8 @@ extension Chat.Message: Codable {}
 
 extension Chat.Message {
     public enum Role: String, Codable {
-        case system, user, assistant
+        case system
+        case user
+        case assistant
     }
 }

--- a/Sources/OpenAIKit/Chat/Chat.swift
+++ b/Sources/OpenAIKit/Chat/Chat.swift
@@ -39,9 +39,9 @@ extension Chat.Choice.FinishReason: Codable {}
 
 extension Chat {
     public enum Message {
-        case system(String)
-        case user(String)
-        case assistant(String)
+        case system(content: String)
+        case user(content: String)
+        case assistant(content: String)
     }
 }
 
@@ -57,11 +57,11 @@ extension Chat.Message: Codable {
         let content = try container.decode(String.self, forKey: .content)
         switch role {
         case "system":
-            self = .system(content)
+            self = .system(content: content)
         case "user":
-            self = .user(content)
+            self = .user(content: content)
         case "assistant":
-            self = .assistant(content)
+            self = .assistant(content: content)
         default:
             throw DecodingError.dataCorruptedError(forKey: .role, in: container, debugDescription: "Invalid type")
         }

--- a/Sources/OpenAIKit/Chat/Chat.swift
+++ b/Sources/OpenAIKit/Chat/Chat.swift
@@ -18,20 +18,34 @@ extension Chat {
     public struct Choice {
         public let index: Int
         public let message: Message
-        public let finishReason: String?
+        public let finishReason: FinishReason?
+        
+        public enum FinishReason: String, Codable {
+            /// API returned complete model output
+            case stop
+            
+            /// Incomplete model output due to max_tokens parameter or token limit
+            case length
+            
+            /// Omitted content due to a flag from our content filters
+            case contentFilter
+            
+            enum CodingKeys: String, CodingKey  {
+                case stop
+                case length
+                case contentFilter = "content_filter"
+            }
+        }
     }
 }
 
 extension Chat.Choice: Codable {}
 
 extension Chat {
-    public struct Message {
-        public let role: Role
-        public let content: String
-        public init(role: Role, content: String) {
-            self.role = role
-            self.content = content
-        }
+    public enum Message {
+        case system(String)
+        case user(String)
+        case assistant(String)
     }
 }
 

--- a/Sources/OpenAIKit/Chat/Chat.swift
+++ b/Sources/OpenAIKit/Chat/Chat.swift
@@ -26,9 +26,9 @@ extension Chat.Choice: Codable {}
 
 extension Chat {
     public struct Message {
-        public let role: String
+        public let role: Role
         public let content: String
-        public init(role: String, content: String) {
+        public init(role: Role, content: String) {
             self.role = role
             self.content = content
         }
@@ -36,3 +36,9 @@ extension Chat {
 }
 
 extension Chat.Message: Codable {}
+
+extension Chat.Message {
+    public enum Role: String, Codable {
+        case system, user, assistant
+    }
+}

--- a/Sources/OpenAIKit/Chat/ChatProvider.swift
+++ b/Sources/OpenAIKit/Chat/ChatProvider.swift
@@ -15,17 +15,17 @@ public struct ChatProvider {
      Creates a chat completion for the provided prompt and parameters
      */
     public func create(
-        model: ModelID,
-        messages: [Chat.Message] = [],
-        temperature: Double = 1.0,
-        topP: Double = 1.0,
-        n: Int = 1,
-        stream: Bool = false,
-        stops: [String] = [],
+        model: ModelID = Model.GPT3.gpt3_5Turbo,
+        messages: [Chat.Message],
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        n: Int? = nil,
+        stream: Bool? = nil,
+        stop: [String]? = nil,
         maxTokens: Int? = nil,
-        presencePenalty: Double = 0.0,
-        frequencyPenalty: Double = 0.0,
-        logitBias: [String : Int] = [:],
+        presencePenalty: Double? = nil,
+        frequencyPenalty: Double? = nil,
+        logitBias: [String : Int]? = nil,
         user: String? = nil
     ) async throws -> Chat {
         
@@ -36,7 +36,7 @@ public struct ChatProvider {
             topP: topP,
             n: n,
             stream: stream,
-            stops: stops,
+            stop: stop,
             maxTokens: maxTokens,
             presencePenalty: presencePenalty,
             frequencyPenalty: frequencyPenalty,

--- a/Sources/OpenAIKit/Chat/CreateChatRequest.swift
+++ b/Sources/OpenAIKit/Chat/CreateChatRequest.swift
@@ -10,16 +10,16 @@ struct CreateChatRequest: Request {
     init(
         model: String,
         messages: [Chat.Message],
-        temperature: Double,
-        topP: Double,
-        n: Int,
-        stream: Bool,
-        stops: [String],
-        maxTokens: Int?,
-        presencePenalty: Double,
-        frequencyPenalty: Double,
-        logitBias: [String: Int],
-        user: String?
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        n: Int? = nil,
+        stream: Bool? = nil,
+        stop: [String]? = nil,
+        maxTokens: Int? = nil,
+        presencePenalty: Double? = nil,
+        frequencyPenalty: Double? = nil,
+        logitBias: [String: Int]? = nil,
+        user: String? = nil
     ) throws {
         
         let body = Body(
@@ -29,7 +29,7 @@ struct CreateChatRequest: Request {
             topP: topP,
             n: n,
             stream: stream,
-            stops: stops,
+            stop: stop,
             maxTokens: maxTokens,
             presencePenalty: presencePenalty,
             frequencyPenalty: frequencyPenalty,
@@ -45,61 +45,30 @@ extension CreateChatRequest {
     struct Body: Encodable {
         let model: String
         let messages: [Chat.Message]
-        let temperature: Double
-        let topP: Double
-        let n: Int
-        let stream: Bool
-        let stops: [String]
+        let temperature: Double?
+        let topP: Double?
+        let n: Int?
+        let stream: Bool?
+        let stop: [String]?
         let maxTokens: Int?
-        let presencePenalty: Double
-        let frequencyPenalty: Double
-        let logitBias: [String: Int]
+        let presencePenalty: Double?
+        let frequencyPenalty: Double?
+        let logitBias: [String: Int]?
         let user: String?
-            
-        enum CodingKeys: CodingKey {
+           
+        private enum CodingKeys: String, CodingKey {
             case model
             case messages
             case temperature
-            case topP
+            case topP = "top_p"
             case n
             case stream
             case stop
-            case maxTokens
-            case presencePenalty
-            case frequencyPenalty
-            case logitBias
+            case maxTokens = "max_tokens"
+            case presencePenalty = "presence_penalty"
+            case frequencyPenalty = "frequency_penalty"
+            case logitBias = "logit_bias"
             case user
-        }
-        
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(model, forKey: .model)
-            
-            if !messages.isEmpty {
-                try container.encode(messages, forKey: .messages)
-            }
-
-            try container.encode(temperature, forKey: .temperature)
-            try container.encode(topP, forKey: .topP)
-            try container.encode(n, forKey: .n)
-            try container.encode(stream, forKey: .stream)
-            
-            if !stops.isEmpty {
-                try container.encode(stops, forKey: .stop)
-            }
-            
-            if let maxTokens {
-                try container.encode(maxTokens, forKey: .maxTokens)
-            }
-            
-            try container.encode(presencePenalty, forKey: .presencePenalty)
-            try container.encode(frequencyPenalty, forKey: .frequencyPenalty)
-            
-            if !logitBias.isEmpty {
-                try container.encode(logitBias, forKey: .logitBias)
-            }
-            
-            try container.encodeIfPresent(user, forKey: .user)
         }
     }
 }

--- a/Sources/OpenAIKit/Request Handler/Request.swift
+++ b/Sources/OpenAIKit/Request Handler/Request.swift
@@ -27,7 +27,7 @@ extension Request {
     }
     
     var keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy { .convertFromSnakeCase }
-    var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy { .millisecondsSince1970 }
+    var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy { .secondsSince1970 }
 }
 
 extension JSONEncoder {

--- a/Sources/OpenAIKit/Request Handler/RequestHandler.swift
+++ b/Sources/OpenAIKit/Request Handler/RequestHandler.swift
@@ -46,7 +46,8 @@ struct RequestHandler {
                 method: request.method,
                 headers: headers,
                 body: request.body
-            )
+            ),
+            deadline: NIODeadline.now() + .minutes(2)            
         ).get()
         
         

--- a/Sources/OpenAIKit/Request Handler/RequestHandler.swift
+++ b/Sources/OpenAIKit/Request Handler/RequestHandler.swift
@@ -46,8 +46,7 @@ struct RequestHandler {
                 method: request.method,
                 headers: headers,
                 body: request.body
-            ),
-            deadline: NIODeadline.now() + .minutes(2)            
+            )         
         ).get()
         
         

--- a/Sources/OpenAIKit/Usage.swift
+++ b/Sources/OpenAIKit/Usage.swift
@@ -2,15 +2,9 @@ import Foundation
 
 public struct Usage {
     public let promptTokens: Int
-    public let completionTokens: Int
+    public let completionTokens: Int?
     public let totalTokens: Int
 }
 
 extension Usage: Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.promptTokens = try container.decodeIfPresent(Int.self, forKey: .promptTokens) ?? 0
-        self.completionTokens = try container.decodeIfPresent(Int.self, forKey: .completionTokens) ?? 0
-        self.totalTokens = try container.decodeIfPresent(Int.self, forKey: .totalTokens) ?? 0
-    }
 }

--- a/Tests/OpenAIKitTests/MessageTests.swift
+++ b/Tests/OpenAIKitTests/MessageTests.swift
@@ -73,13 +73,13 @@ final class MessageTests: XCTestCase {
     }
     
     func testMessageRoundtrip() throws {
-        let message = Chat.Message.system("You are a helpful assistant that translates English to French.")
+        let message = Chat.Message.system(content: "You are a helpful assistant that translates English to French.")
         let encoded = try encoder.encode(message)
         let decoded = try decoder.decode(Chat.Message.self, from: encoded)
         print(String(data: encoded, encoding: .utf8)!)
         switch decoded {
         case .system(let content):
-            guard case let .system(original) = message else {
+            guard case let .system(content: original) = message else {
                 XCTFail()
                 return
             }
@@ -134,8 +134,8 @@ final class MessageTests: XCTestCase {
     func testChatRequest() throws {
         let request = try CreateChatRequest(model: "gpt-3.5-turbo", //.gpt3_5Turbo,
                           messages: [
-                            .system("You are Malcolm Tucker from The Thick of It, an unfriendly assistant for writing mail and explaining science and history. You write text in your voice for me."),
-                            .user("tell me a joke"),
+                            .system(content: "You are Malcolm Tucker from The Thick of It, an unfriendly assistant for writing mail and explaining science and history. You write text in your voice for me."),
+                            .user(content: "tell me a joke"),
                           ],
                           temperature: 1.0)
         print(request.body)

--- a/Tests/OpenAIKitTests/MessageTests.swift
+++ b/Tests/OpenAIKitTests/MessageTests.swift
@@ -1,0 +1,143 @@
+//
+//  MessageTests.swift
+//  
+//
+//  Created by Ronald Mannak on 3/6/23.
+//
+
+import XCTest
+@testable import OpenAIKit
+
+final class MessageTests: XCTestCase {
+    
+    let decoder = JSONDecoder()
+    let encoder = JSONEncoder()
+
+    override func setUpWithError() throws {
+        decoder.dateDecodingStrategy = .secondsSince1970
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testFinishReasonContentFilterCoding() throws {
+        let filter: Chat.Choice.FinishReason = .contentFilter
+        let encoded = try encoder.encode(filter)
+        XCTAssertEqual("\"content_filter\"", String(data: encoded, encoding: .utf8)!)
+        
+        let decoded = try decoder.decode(Chat.Choice.FinishReason.self, from: encoded)
+        XCTAssertEqual(decoded, Chat.Choice.FinishReason.contentFilter)
+        XCTAssertNotEqual(decoded, Chat.Choice.FinishReason.length)
+        XCTAssertNotEqual(decoded, Chat.Choice.FinishReason.stop)
+    }
+    
+    func testFinishReasonLengthCoding() throws {
+        let filter: Chat.Choice.FinishReason = .length
+        let encoded = try encoder.encode(filter)
+        XCTAssertEqual("\"length\"", String(data: encoded, encoding: .utf8)!)
+        
+        let decoded = try decoder.decode(Chat.Choice.FinishReason.self, from: encoded)
+        XCTAssertEqual(decoded, Chat.Choice.FinishReason.length)
+        XCTAssertNotEqual(decoded, Chat.Choice.FinishReason.contentFilter)
+        XCTAssertNotEqual(decoded, Chat.Choice.FinishReason.stop)
+    }
+    
+    func testFinishStopCoding() throws {
+        let filter: Chat.Choice.FinishReason = .stop
+        let encoded = try encoder.encode(filter)
+        XCTAssertEqual("\"stop\"", String(data: encoded, encoding: .utf8)!)
+        
+        let decoded = try decoder.decode(Chat.Choice.FinishReason.self, from: encoded)
+        XCTAssertEqual(decoded, Chat.Choice.FinishReason.stop)
+        XCTAssertNotEqual(decoded, Chat.Choice.FinishReason.contentFilter)
+        XCTAssertNotEqual(decoded, Chat.Choice.FinishReason.length)
+    }
+    
+    
+    func testMessageCoding() throws {
+        let messageData = """
+            {"role": "user", "content": "Translate the following English text to French: "}
+            """.data(using: .utf8)!
+        let message = try decoder.decode(Chat.Message.self, from: messageData)
+        switch message {
+        case .system(_):
+            XCTFail("incorrect role")
+        case .user(let content):
+            XCTAssertEqual(content, "Translate the following English text to French: ")
+        case .assistant(_):
+            XCTFail("incorrect role")
+        }
+    }
+    
+    func testMessageRoundtrip() throws {
+        let message = Chat.Message.system("You are a helpful assistant that translates English to French.")
+        let encoded = try encoder.encode(message)
+        let decoded = try decoder.decode(Chat.Message.self, from: encoded)
+        print(String(data: encoded, encoding: .utf8)!)
+        switch decoded {
+        case .system(let content):
+            guard case let .system(original) = message else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual(content, original)
+        case .user(_):
+            XCTFail("incorrect role")
+        case .assistant(_):
+            XCTFail("incorrect role")
+        }
+    }
+
+    func testChatDecoding() throws {
+        let exampleResponse = """
+            {
+             "id": "chatcmpl-6p9XYPYSTTRi0xEviKjjilqrWU2Ve",
+             "object": "chat.completion",
+             "created": 1677649420,
+             "model": "gpt-3.5-turbo",
+             "usage": {"prompt_tokens": 56, "completion_tokens": 31, "total_tokens": 87},
+             "choices": [
+               {
+                "message": {
+                  "role": "assistant",
+                  "content": "The 2020 World Series was played in Arlington, Texas at the Globe Life Field, which was the new home stadium for the Texas Rangers."},
+                "finish_reason": "stop",
+                "index": 0
+               }
+              ]
+            }
+            """.data(using: .utf8)!
+        let chat = try decoder.decode(Chat.self, from: exampleResponse)
+        XCTAssertEqual(chat.id, "chatcmpl-6p9XYPYSTTRi0xEviKjjilqrWU2Ve")
+        XCTAssertEqual(chat.created.timeIntervalSince1970, 1677649420)
+        XCTAssertEqual(chat.usage.promptTokens, 56)
+        XCTAssertEqual(chat.usage.completionTokens, 31)
+        XCTAssertEqual(chat.usage.totalTokens, 87)
+        
+        XCTAssertEqual(chat.choices.count, 1)
+        let firstChoice = chat.choices.first!
+//        XCTAssertEqual(firstChoice.finishReason, .stop)
+        XCTAssertEqual(firstChoice.index, 0)
+        switch firstChoice.message {
+        case .system(_):
+            XCTFail()
+        case .assistant(let content):
+            XCTAssertEqual(content, "The 2020 World Series was played in Arlington, Texas at the Globe Life Field, which was the new home stadium for the Texas Rangers.")
+        case .user(_):
+            XCTFail()
+        }
+    }
+    
+    func testChatRequest() throws {
+        let request = try CreateChatRequest(model: "gpt-3.5-turbo", //.gpt3_5Turbo,
+                          messages: [
+                            .system("You are Malcolm Tucker from The Thick of It, an unfriendly assistant for writing mail and explaining science and history. You write text in your voice for me."),
+                            .user("tell me a joke"),
+                          ],
+                          temperature: 1.0)
+        print(request.body)
+    }
+}

--- a/Tests/OpenAIKitTests/OpenAIKitTests.swift
+++ b/Tests/OpenAIKitTests/OpenAIKitTests.swift
@@ -54,7 +54,7 @@ final class OpenAIKitTests: XCTestCase {
         let completion = try await client.chats.create(
             model: Model.GPT3.gpt3_5Turbo,
             messages: [
-                .user("Write a haiku")                
+                .user(content: "Write a haiku")                
             ]
         )
         

--- a/Tests/OpenAIKitTests/OpenAIKitTests.swift
+++ b/Tests/OpenAIKitTests/OpenAIKitTests.swift
@@ -54,10 +54,7 @@ final class OpenAIKitTests: XCTestCase {
         let completion = try await client.chats.create(
             model: Model.GPT3.gpt3_5Turbo,
             messages: [
-                Chat.Message(
-                    role: .user,
-                    content: "Write a haiku"
-                )
+                .user("Write a haiku")                
             ]
         )
         

--- a/Tests/OpenAIKitTests/OpenAIKitTests.swift
+++ b/Tests/OpenAIKitTests/OpenAIKitTests.swift
@@ -55,7 +55,7 @@ final class OpenAIKitTests: XCTestCase {
             model: Model.GPT3.gpt3_5Turbo,
             messages: [
                 Chat.Message(
-                    role: "user",
+                    role: .user,
                     content: "Write a haiku"
                 )
             ]


### PR DESCRIPTION
Warning: this PR will break the existing Chat.Message API introduced in #10 

The role property in Message can only have three values: system, user, and assistant. For simplicity, it makes sense to create a Role enum for these values, which is what this PR proposes.