### PR TITLE
Send Array as embeddings input

### DIFF
--- a/Sources/OpenAIKit/Embedding/CreateEmbeddingRequest.swift
+++ b/Sources/OpenAIKit/Embedding/CreateEmbeddingRequest.swift
@@ -9,7 +9,7 @@ struct CreateEmbeddingRequest: Request {
     
     init(
         model: String,
-        input: String,
+        input: [String],
         user: String?
     ) throws {
         
@@ -26,7 +26,7 @@ struct CreateEmbeddingRequest: Request {
 extension CreateEmbeddingRequest {
     struct Body: Encodable {
         let model: String
-        let input: String
+        let input: [String]
         let user: String?
     }
 }

--- a/Sources/OpenAIKit/Embedding/EmbeddingProvider.swift
+++ b/Sources/OpenAIKit/Embedding/EmbeddingProvider.swift
@@ -5,11 +5,35 @@ public struct EmbeddingProvider {
     init(requestHandler: RequestHandler) {
         self.requestHandler = requestHandler
     }
-    
+
     /**
      Create embeddings
      POST
-      
+
+     https://api.openai.com/v1/embeddings
+
+     Creates an embedding vector representing the input text.
+     */
+    public func create(
+        model: ModelID = Model.GPT3.textEmbeddingAda001,
+        input: [String],
+        user: String? = nil
+    ) async throws -> CreateEmbeddingResponse {
+
+        let request = try CreateEmbeddingRequest(
+            model: model.id,
+            input: input,
+            user: user
+        )
+
+        return try await requestHandler.perform(request: request)
+    }
+
+
+    /**
+     Create embeddings
+     POST
+
      https://api.openai.com/v1/embeddings
 
      Creates an embedding vector representing the input text.
@@ -19,14 +43,6 @@ public struct EmbeddingProvider {
         input: String,
         user: String? = nil
     ) async throws -> CreateEmbeddingResponse {
-        
-        let request = try CreateEmbeddingRequest(
-            model: model.id,
-            input: input,
-            user: user
-        )
-        
-        return try await requestHandler.perform(request: request)
+        try await create(model: model, input: [input], user: user)
     }
-    
 }


### PR DESCRIPTION
The API states that embeddings can either be a string or an array of strings: https://platform.openai.com/docs/api-reference/embeddings/create

This PR modifies the default behavior to send an array of strings and adds an overload to send a single String, for backwards compatibility and ease of use.