### PR TITLE
call correct httpClient syncShutdown()

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ var organization: String {
 ...
 
 let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+defer {
+    try? httpClient.syncShutdown()
+}
 let configuration = Configuration(apiKey: apiKey, organization: organization)
 
 let openAIClient = OpenAIKit.Client(httpClient: httpClient, configuration: configuration)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ var organization: String {
 
 let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
 defer {
+    // it's important to shutdown the httpClient after all requests are done, even if one failed. See: https://github.com/swift-server/async-http-client
     try? httpClient.syncShutdown()
 }
 let configuration = Configuration(apiKey: apiKey, organization: organization)

--- a/Tests/OpenAIKitTests/OpenAIKitTests.swift
+++ b/Tests/OpenAIKitTests/OpenAIKitTests.swift
@@ -18,7 +18,7 @@ final class OpenAIKitTests: XCTestCase {
         )
     }
     
-    override func tearDown() async throws {
+    override func tearDownWithError() throws {
         try httpClient.syncShutdown()
     }
     

--- a/Tests/OpenAIKitTests/OpenAIKitTests.swift
+++ b/Tests/OpenAIKitTests/OpenAIKitTests.swift
@@ -19,7 +19,7 @@ final class OpenAIKitTests: XCTestCase {
     }
     
     override func tearDown() async throws {
-        try await httpClient.shutdown()
+        try httpClient.syncShutdown()
     }
     
     func test_error() async throws {


### PR DESCRIPTION
The httpClient is shutdown incorrectly in the unit tests and undocumented in the documentation. This will lead to an assertionFailure in debug mode.  