### PR TITLE
Shutdown HTTPClient in deinit of Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ OPENAI_ORGANIZATION="YOUR-ORGANIZATION"
 ~~~~
 ⚠️ OpenAI strongly recommends developers of client-side applications proxy requests through a separate backend service to keep their API key safe. API keys can access and manipulate customer billing, usage, and organizational data, so it's a significant risk to [expose](https://nshipster.com/secrets/) them.
 
-Create a `OpenAIKit.Client` using a httpClient and configuration.
+Create a `OpenAIKit.Client` by passing a configuration.
 
 ~~~~swift
 
@@ -45,6 +45,20 @@ var organization: String {
 let configuration = Configuration(apiKey: apiKey, organization: organization)
 
 let openAIClient = OpenAIKit.Client(configuration: configuration)
+~~~~
+
+By default, a `HTTPClient` will be internally managed by the framework. For more granular control, you may also instantiate the `OpenAIKit.Client` by passing in your own `HTTPClient`. 
+
+~~~~swift
+...
+
+let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+defer {
+    // it's important to shutdown the httpClient after all requests are done, even if one failed. See: https://github.com/swift-server/async-http-client
+    try? httpClient.syncShutdown()
+}
+
+let openAIClient = OpenAIKit.Client(httpClient: httpClient, configuration: configuration)
 ~~~~
 
 ## Using the API

--- a/README.md
+++ b/README.md
@@ -42,14 +42,9 @@ var organization: String {
 
 ...
 
-let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
-defer {
-    // it's important to shutdown the httpClient after all requests are done, even if one failed. See: https://github.com/swift-server/async-http-client
-    try? httpClient.syncShutdown()
-}
 let configuration = Configuration(apiKey: apiKey, organization: organization)
 
-let openAIClient = OpenAIKit.Client(httpClient: httpClient, configuration: configuration)
+let openAIClient = OpenAIKit.Client(configuration: configuration)
 ~~~~
 
 ## Using the API

--- a/Sources/OpenAIKit/Client/Client.swift
+++ b/Sources/OpenAIKit/Client/Client.swift
@@ -42,6 +42,12 @@ public final class Client {
     }
     
     deinit {
+        /**
+         syncShutdown() must not be called when on an EventLoop.
+         Calling syncShutdown() on any EventLoop can lead to deadlocks.
+         */
+        guard MultiThreadedEventLoopGroup.currentEventLoop == nil else { return }
+        
         try? httpClient.syncShutdown()
     }
 

--- a/Sources/OpenAIKit/Client/Client.swift
+++ b/Sources/OpenAIKit/Client/Client.swift
@@ -3,7 +3,7 @@ import NIO
 import NIOHTTP1
 import Foundation
 
-public struct Client {
+public final class Client {
     
     public let audio: AudioProvider
     public let chats: ChatProvider
@@ -14,11 +14,15 @@ public struct Client {
     public let images: ImageProvider
     public let models: ModelProvider
     public let moderations: ModerationProvider
+    
+    private let httpClient: HTTPClient
 
     public init(
-        httpClient: HTTPClient,
+        httpClient: HTTPClient = HTTPClient(eventLoopGroupProvider: .createNew),
         configuration: Configuration
     ) {
+        
+        self.httpClient = httpClient
 
         let requestHandler = RequestHandler(
             httpClient: httpClient,
@@ -35,6 +39,10 @@ public struct Client {
         self.files = FileProvider(requestHandler: requestHandler)
         self.moderations = ModerationProvider(requestHandler: requestHandler)
         
+    }
+    
+    deinit {
+        try? httpClient.syncShutdown()
     }
 
 }

--- a/Tests/OpenAIKitTests/OpenAIKitTests.swift
+++ b/Tests/OpenAIKitTests/OpenAIKitTests.swift
@@ -31,6 +31,17 @@ final class OpenAIKitTests: XCTestCase {
         
     }
     
+    func test_usingInternalHTTPClient() async throws {
+        
+        let client = Client(
+            configuration: .init(apiKey: "YOUR-API-KEY")
+        )
+        
+        let models = try await client.models.list()
+        print(models)
+        
+    }
+    
     func test_listModels() async throws {
         let models = try await client.models.list()
         print(models)


### PR DESCRIPTION
@ronaldmannak In an effort to clean up the API, and abstract the use of HTTPClient for basic use cases, I thought providing a default HTTPClient would simplify things. Curious on your thoughts.