### PR TITLE
Expose content of Chat.Message

### DIFF
--- a/Sources/OpenAIKit/Chat/Chat.swift
+++ b/Sources/OpenAIKit/Chat/Chat.swift
@@ -82,3 +82,16 @@ extension Chat.Message: Codable {
         }
     }
 }
+
+extension Chat.Message {
+    public var content: String {
+        switch self {
+        case .system(let content):
+            return content
+        case .user(let content):
+            return content
+        case .assistant(let content):
+            return content
+        }
+    }
+}


### PR DESCRIPTION
This directly exposes the content string of the Message object, which makes handling the response from a call to the chat endpoint easier. Alternatively, Message could be a struct instead of an enum? Lmk what you think.

Example usage
```
let response = try await openAIClient.chats.create(
    model: Model.GPT3.gpt3_5Turbo,
    messages: [userMessage]
)

let message: Chat.Message = response.choices.first!.message 
// .assistant(content: "This is message content.")

let content: String = message.content 
// This is message content.
```