### PR TITLE
Revert injection of HTTPClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,24 +42,23 @@ var organization: String {
 
 ...
 
-let configuration = Configuration(apiKey: apiKey, organization: organization)
+// Generally we would advise on creating a single HTTPClient for the lifecycle of your application and recommend shutting it down on application close.
 
-let openAIClient = OpenAIKit.Client(configuration: configuration)
-~~~~
+let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
-By default, a `HTTPClient` will be internally managed by the framework. For more granular control, you may also instantiate the `OpenAIKit.Client` by passing in your own `HTTPClient`. 
+let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
 
-~~~~swift
-...
-
-let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
 defer {
     // it's important to shutdown the httpClient after all requests are done, even if one failed. See: https://github.com/swift-server/async-http-client
     try? httpClient.syncShutdown()
 }
 
+let configuration = Configuration(apiKey: apiKey, organization: organization)
+
 let openAIClient = OpenAIKit.Client(httpClient: httpClient, configuration: configuration)
+
 ~~~~
+
 
 ## Using the API
 

--- a/Sources/OpenAIKit/Client/Client.swift
+++ b/Sources/OpenAIKit/Client/Client.swift
@@ -3,7 +3,7 @@ import NIO
 import NIOHTTP1
 import Foundation
 
-public final class Client {
+public struct Client {
     
     public let audio: AudioProvider
     public let chats: ChatProvider
@@ -15,20 +15,13 @@ public final class Client {
     public let models: ModelProvider
     public let moderations: ModerationProvider
     
-    // Hold onto reference of internally created HTTPClient to perform appropriate shutdowns.
-    private let _httpClient: HTTPClient?
-
     public init(
-        // If an HTTPClient is not provided, an internal one will be created, and will be shutdown after the lifecycle of the Client
-        httpClient: HTTPClient? = nil,
+        httpClient: HTTPClient,
         configuration: Configuration
     ) {
-        
-        // If an httpClient is provided, don't hold reference to it.
-        self._httpClient = httpClient == nil ? HTTPClient(eventLoopGroupProvider: .createNew) : nil
-        
+
         let requestHandler = RequestHandler(
-            httpClient: httpClient ?? _httpClient!,
+            httpClient: httpClient,
             configuration: configuration
         )
         
@@ -42,16 +35,6 @@ public final class Client {
         self.files = FileProvider(requestHandler: requestHandler)
         self.moderations = ModerationProvider(requestHandler: requestHandler)
         
-    }
-    
-    deinit {
-        /**
-         syncShutdown() must not be called when on an EventLoop.
-         Calling syncShutdown() on any EventLoop can lead to deadlocks.
-         */
-        guard MultiThreadedEventLoopGroup.currentEventLoop == nil else { return }
-        
-        try? _httpClient?.syncShutdown()
     }
 
 }

--- a/Tests/OpenAIKitTests/OpenAIKitTests.swift
+++ b/Tests/OpenAIKitTests/OpenAIKitTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import NIOPosix
 import AsyncHTTPClient
 @testable import OpenAIKit
 
@@ -8,7 +9,10 @@ final class OpenAIKitTests: XCTestCase {
     private var client: Client!
     
     override func setUp() {
-        httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+        
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+        httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
         
         let configuration = Configuration(apiKey: "YOUR-API-KEY")
         
@@ -28,17 +32,6 @@ final class OpenAIKitTests: XCTestCase {
         } catch {
             print(error)
         }
-        
-    }
-    
-    func test_usingInternalHTTPClient() async throws {
-        
-        let client = Client(
-            configuration: .init(apiKey: "YOUR-API-KEY")
-        )
-        
-        let models = try await client.models.list()
-        print(models)
         
     }
     


### PR DESCRIPTION
After discussing with members of the Swift Server Workgroup (https://www.swift.org/sswg/ ), I've come to the conclusion that we'll need to revert the Client initializer back to injecting the HTTPClient.

Their recommendations are as follows:

1. Normally users should have one HTTPClient per app. HTTPClients should be long-lived since they pool the connections for you.
2. Calling a sync shutdown in a deinit may block the concurrent executor, which can lead to unexpected hangs. Especially if you use your client from an async/await context.

Generally, we would advise creating a single HTTPClient on startup and shutting it down on application close. Automatically shutting it down in deinit leads to patterns where users create HTTPClients over and over which is bad performance-wise since the underlying connection pool can not be shared over multiple executions.

