### PR TITLE
Make ChatStream properties public

### DIFF
--- a/Sources/OpenAIKit/Chat/ChatStream.swift
+++ b/Sources/OpenAIKit/Chat/ChatStream.swift
@@ -12,9 +12,9 @@ extension ChatStream: Codable {}
 
 extension ChatStream {
     public struct Choice {
-        let index: Int
-        let finishReason: FinishReason?
-        let delta: ChatStream.Choice.Message
+        public let index: Int
+        public let finishReason: FinishReason?
+        public let delta: ChatStream.Choice.Message
     }
 }
 
@@ -22,8 +22,8 @@ extension ChatStream.Choice: Codable {}
 
 extension ChatStream.Choice {
     public struct Message {
-        let content: String?
-        let role: String?
+        public let content: String?
+        public let role: String?
     }
 }
 


### PR DESCRIPTION
properties of Choice and Message should be public.

@dylanshine: I encountered one weird bug. The first call to stream always fails. Chats.stream(model:, ...) returns an empty stream and the for try await loop to print the delta is skipped over. Subsequent calls succeed. Can you confirm you see the same?