### PR TITLE
Fix crash after Task cancellation by removing unneeded error processing

### DIFF
--- a/Sources/OpenAIKit/RequestHandler/RequestHandler.swift
+++ b/Sources/OpenAIKit/RequestHandler/RequestHandler.swift
@@ -107,16 +107,7 @@ struct RequestHandler {
                     }
                     continuation.finish()
                 } catch {
-                    
-                    let data = try? await response.body.reduce(into: Data()) { $0.append(.init(buffer: $1)) }
-                    
-                    if let data = data,
-                       let apiError = try? decoder.decode(APIErrorResponse.self, from: data) {
-                        continuation.finish(throwing: apiError)
-                    } else {
-                        continuation.finish(throwing: error)
-                    }
-        
+                    continuation.finish(throwing: error)
                 }
             }
         }


### PR DESCRIPTION
- After Task cancellation, this preconditionFailure was triggered: "Tried to use a second iterator on response body stream. Multiple iterators are not supported."
- Also the following: fatalError("NIOThrowingAsyncSequenceProducer allows only a single AsyncIterator to be created")