### PR TITLE
Add content setter for Chat.Message

### DIFF
--- a/Sources/OpenAIKit/Chat/Chat.swift
+++ b/Sources/OpenAIKit/Chat/Chat.swift
@@ -72,9 +72,18 @@ extension Chat.Message: Codable {
 
 extension Chat.Message {
     public var content: String {
-        switch self {
-        case .system(let content), .user(let content), .assistant(let content):
-            return content
+        get {
+            switch self {
+            case .system(let content), .user(let content), .assistant(let content):
+                return content
+            }
+        }
+        set {
+            switch self {
+            case .system: self = .system(content: newValue)
+            case .user: self = .user(content: newValue)
+            case .assistant: self = .assistant(content: newValue)
+            }
         }
     }
 }


### PR DESCRIPTION
I believe that this feature can be quite useful, particularly when using the stream for response and preserving the original structures from the framework to display chat in UI. With this feature, whenever a new update is received, you can simply add the new content to the previous message. Anyway, it's just a suggestion to improve usability. 