### PR TITLE
Add .m4a audio support to speech-to-text API.

### DIFF
--- a/Sources/OpenAIKit/MIMEType.swift
+++ b/Sources/OpenAIKit/MIMEType.swift
@@ -1,6 +1,6 @@
 //
 //  MIMEType.swift
-//  
+//
 //
 //  Created by Dylan Shine on 3/19/23.
 //
@@ -8,18 +8,19 @@
 import Foundation
 
 public enum MIMEType {
-    
+
     public enum File: String {
         case json = "application/json"
     }
-    
+
     public enum Audio: String {
         case mpeg = "audio/mpeg"
         case mp4 = "audio/mp4"
         case wav = "audio/wav"
         case webm = "audio/webm"
+        case m4a = "audio/m4a"
     }
-    
+
 }
 
 extension MIMEType.File: Codable {}


### PR DESCRIPTION
Solves issue #53. Personally tested on my end to work with audio files created by AVAudioRecorder using settings of:
```
[ 
  AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
  AVSampleRateKey: 12000,
  AVNumberOfChannelsKey: 1,
  AVEncoderAudioQualityKey: AVAudioQuality.max.rawValue
]
```