### PR TITLE
Add basic support for functions

### DIFF
--- a/Sources/OpenAIKit/Chat/Chat.swift
+++ b/Sources/OpenAIKit/Chat/Chat.swift
@@ -25,30 +25,153 @@ extension Chat {
 extension Chat.Choice: Codable {}
 
 extension Chat {
+    
+    public enum FunctionMode {
+        case none
+        case auto
+        case named(String)
+    }
+}
+
+extension Chat.FunctionMode: Codable {
+    
+    private struct Named: Codable {
+        let name: String
+    }
+    
+    public init(from decoder: Decoder) throws {
+        do {
+            let container = try decoder.singleValueContainer()
+            let singleStringValue = try container.decode(String.self)
+            
+            switch singleStringValue {
+            case "none":
+                self = .none
+            case "auto":
+                self = .auto
+            default:
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Invalid type"
+                )
+            }
+        } catch {
+            let parameterized = try Named(from: decoder)
+            self = .named(parameterized.name)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .none:
+            var container = encoder.singleValueContainer()
+            try container.encode("none")
+        case .auto:
+            var container = encoder.singleValueContainer()
+            try container.encode("auto")
+        case .named(let string):
+            try Named(name: string).encode(to: encoder)
+        }
+    }
+}
+
+public protocol ChatFunction: Encodable {
+    associatedtype Parameters: Encodable
+    
+    var name: String { get }
+    var description: String? { get }
+    var parameters: Parameters? { get }
+}
+
+public protocol ChatFunctionCall: Codable {
+    var name: String { get }
+    init(name: String)
+}
+
+public protocol ChatFunctionCallWithArguments: Codable {
+    associatedtype Arguments: Codable
+    
+    var name: String { get }
+    var arguments: Arguments { get }
+    
+    init(name: String, arguments: Arguments)
+}
+
+public struct UnstructuredChatFunctionCall: Codable {
+    let name: String
+    let arguments: String?
+    
+    public func structured<T: ChatFunctionCall>(as callType: T.Type, decoder: JSONDecoder = JSONDecoder()) throws -> T {
+        callType.init(name: name)
+    }
+    
+    public func structured<T: ChatFunctionCallWithArguments>(as callType: T.Type, decoder: JSONDecoder = JSONDecoder()) throws -> T {
+        if let arguments {
+            let data = Data(arguments.utf8)
+            let parsedArgs = try decoder.decode(callType.Arguments, from: data)
+            return callType.init(name: name, arguments: parsedArgs)
+        }
+        throw NSError(domain: "", code: -1)
+    }
+}
+
+public extension Chat {
+    typealias Function = ChatFunction
+    typealias UnstructuredFunctionCall = UnstructuredChatFunctionCall
+    typealias FunctionCall = ChatFunctionCall
+    typealias FunctionCallWithArguments = ChatFunctionCallWithArguments
+}
+
+extension Chat {
+    
     public enum Message {
         case system(content: String)
         case user(content: String)
         case assistant(content: String)
+        case assistantWithCall(content: String?, call: UnstructuredFunctionCall)
+        case function(content: String?, name: String, call: UnstructuredFunctionCall?)
     }
 }
 
 extension Chat.Message: Codable {
+    
     private enum CodingKeys: String, CodingKey {
         case role
         case content
+        case name
+        case functionCall
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let role = try container.decode(String.self, forKey: .role)
-        let content = try container.decode(String.self, forKey: .content)
+        
         switch role {
         case "system":
+            let content = try container.decode(String.self, forKey: .content)
             self = .system(content: content)
         case "user":
+            let content = try container.decode(String.self, forKey: .content)
             self = .user(content: content)
         case "assistant":
-            self = .assistant(content: content)
+            
+            if let call = try container.decodeIfPresent(UnstructuredChatFunctionCall.self, forKey: .functionCall) {
+                let content = try container.decodeIfPresent(String.self, forKey: .content)
+                self = .assistantWithCall(content: content, call: call)
+                
+            } else {
+                
+                let content = try container.decode(String.self, forKey: .content)
+                self = .assistant(content: content)
+            }
+            
+        case "function":
+            
+            let call = try container.decodeIfPresent(UnstructuredChatFunctionCall.self, forKey: .functionCall)
+            
+            let content = try container.decodeIfPresent(String.self, forKey: .content)
+            let name = try container.decode(String.self, forKey: .name)
+            self = .function(content: content, name: name, call: call)
         default:
             throw DecodingError.dataCorruptedError(forKey: .role, in: container, debugDescription: "Invalid type")
         }
@@ -66,16 +189,28 @@ extension Chat.Message: Codable {
         case .assistant(let content):
             try container.encode("assistant", forKey: .role)
             try container.encode(content, forKey: .content)
+        case let .assistantWithCall(content, call):
+            try container.encode("assistant", forKey: .role)
+            try container.encode(call, forKey: .functionCall)
+            try container.encodeIfPresent(content, forKey: .content)
+        case let .function(content, name, call):
+            try container.encode("function", forKey: .role)
+            try container.encode(name, forKey: .name)
+            try container.encodeIfPresent(call, forKey: .functionCall)
+            try container.encodeIfPresent(content, forKey: .content)
         }
     }
 }
 
 extension Chat.Message {
+    
     public var content: String {
         get {
             switch self {
             case .system(let content), .user(let content), .assistant(let content):
                 return content
+            case .assistantWithCall(let content, _), .function(let content, _, _):
+                return content ?? ""
             }
         }
         set {
@@ -83,6 +218,10 @@ extension Chat.Message {
             case .system: self = .system(content: newValue)
             case .user: self = .user(content: newValue)
             case .assistant: self = .assistant(content: newValue)
+            case let .function(_, name, call):
+                self = .function(content: newValue, name: name, call: call)
+            case let .assistantWithCall(_, call):
+                self = .assistantWithCall(content: newValue, call: call)
             }
         }
     }

--- a/Sources/OpenAIKit/Chat/ChatProvider.swift
+++ b/Sources/OpenAIKit/Chat/ChatProvider.swift
@@ -17,6 +17,8 @@ public struct ChatProvider {
     public func create(
         model: ModelID,
         messages: [Chat.Message] = [],
+        functions: [any Chat.Function] = [],
+        functionMode: Chat.FunctionMode = .none,
         temperature: Double = 1.0,
         topP: Double = 1.0,
         n: Int = 1,
@@ -31,6 +33,8 @@ public struct ChatProvider {
         let request = try CreateChatRequest(
             model: model.id,
             messages: messages,
+            functions: functions,
+            functionMode: functionMode,
             temperature: temperature,
             topP: topP,
             n: n,
@@ -63,6 +67,8 @@ public struct ChatProvider {
     public func stream(
         model: ModelID,
         messages: [Chat.Message] = [],
+        functions: [any Chat.Function] = [],
+        functionMode: Chat.FunctionMode = .none,
         temperature: Double = 1.0,
         topP: Double = 1.0,
         n: Int = 1,
@@ -77,6 +83,8 @@ public struct ChatProvider {
         let request = try CreateChatRequest(
             model: model.id,
             messages: messages,
+            functions: functions,
+            functionMode: functionMode,
             temperature: temperature,
             topP: topP,
             n: n,

--- a/Sources/OpenAIKit/Chat/CreateChatRequest.swift
+++ b/Sources/OpenAIKit/Chat/CreateChatRequest.swift
@@ -10,6 +10,8 @@ struct CreateChatRequest: Request {
     init(
         model: String,
         messages: [Chat.Message],
+        functions: [any Chat.Function],
+        functionMode: Chat.FunctionMode,
         temperature: Double,
         topP: Double,
         n: Int,
@@ -25,6 +27,8 @@ struct CreateChatRequest: Request {
         let body = Body(
             model: model,
             messages: messages,
+            functions: functions,
+            functionCall: functionMode,
             temperature: temperature,
             topP: topP,
             n: n,
@@ -45,6 +49,8 @@ extension CreateChatRequest {
     struct Body: Encodable {
         let model: String
         let messages: [Chat.Message]
+        let functions: [any Chat.Function]
+        let functionCall: Chat.FunctionMode
         let temperature: Double
         let topP: Double
         let n: Int
@@ -59,6 +65,8 @@ extension CreateChatRequest {
         enum CodingKeys: CodingKey {
             case model
             case messages
+            case functions
+            case functionCall
             case temperature
             case topP
             case n
@@ -77,6 +85,14 @@ extension CreateChatRequest {
             
             if !messages.isEmpty {
                 try container.encode(messages, forKey: .messages)
+            }
+            
+            if !functions.isEmpty {
+                var nestedContainer = container.nestedUnkeyedContainer(forKey: .functions)
+                try functions.forEach {
+                    try nestedContainer.encode($0)
+                }
+                try container.encode(functionCall, forKey: .functionCall)
             }
 
             try container.encode(temperature, forKey: .temperature)

--- a/Sources/OpenAIKit/Chat/FinishReason.swift
+++ b/Sources/OpenAIKit/Chat/FinishReason.swift
@@ -9,6 +9,9 @@ public enum FinishReason: String {
     
     /// Omitted content due to a flag from our content filters
     case contentFilter = "content_filter"
+    
+    /// ...
+    case functionCall = "function_call"
 }
 
 extension FinishReason: Codable {}

--- a/Sources/OpenAIKit/Model/Model.swift
+++ b/Sources/OpenAIKit/Model/Model.swift
@@ -38,6 +38,7 @@ extension Model {
     public enum GPT4: String, ModelID {
         case gpt4 = "gpt-4"
         case gpt40314 = "gpt-4-0314"
+        case gpt40613 = "gpt-4-0613"
         case gpt4_32k = "gpt-4-32k"
         case gpt4_32k0314 = "gpt-4-32k-0314"
     }


### PR DESCRIPTION
Hi all! I've started working on adding support for functions. I have a rather rough implementation ready, so I wanted to check in here. Function calls from the models are inherently "unsafe", so this clashes a bit with the strict type safety of Swift; I think making this work in a neat way is an interesting challenge. What are your thoughts?

Here's how you'd define a function with my implementation (this example function can be used to search a database of recipes):

```swift
struct FindRecipeFunction: Chat.Function {
    
    struct Call: Chat.FunctionCallWithArguments {
        var name: String
        var arguments: Arguments
        
        struct Arguments: Codable {
            let query: String
        }
    }
    
    struct Parameters: Encodable {
        let type = "object"
        let properties = Props()
        let required = ["query"]
        
        struct Props: Encodable {
            let query = Query()
            
            struct Query: Encodable {
                let type = "string"
                let description = "A human readable query to use when searching for a recipe."
            }
        }
    }
    
    let name: String = "findRecipe"
    
    let description: String? = "The `findRecipe` API can be used to search through a database of recipes."
    
    let parameters: Parameters? = Parameters()
}
```

You would then send a chat request as usual, passing in the functions and the function "mode" (called "function_call" in the docs):

```swift
let chat = try await client.chats.create(
    model: Model.GPT4.gpt40613,
    messages: ...,
    functions: [FindRecipeFunction()],
    functionMode: .auto
)
let message = chat.choices[0].message
```

And then try to extract any function calls with type safety:

```swift
if case let .assistantWithCall(_, call) = message,
    let call = try? call.structured(as: FindRecipeFunction.Call.self) {
    
    let recipeQuery = call.arguments.query
    // ...
}
```