### PR TITLE
Add gpt-4-1106-preview

### DIFF
--- a/Sources/OpenAIKit/Chat/Chat.swift
+++ b/Sources/OpenAIKit/Chat/Chat.swift
@@ -25,7 +25,7 @@ extension Chat {
 extension Chat.Choice: Codable {}
 
 extension Chat {
-    public enum Message {
+    public enum Message: Hashable {
         case system(content: String)
         case user(content: String)
         case assistant(content: String)

--- a/Sources/OpenAIKit/Model/Model.swift
+++ b/Sources/OpenAIKit/Model/Model.swift
@@ -40,6 +40,7 @@ extension Model {
         case gpt40314 = "gpt-4-0314"
         case gpt4_32k = "gpt-4-32k"
         case gpt4_32k0314 = "gpt-4-32k-0314"
+        case gpt4_1106_preview = "gpt-4-1106-preview"
     }
 
     public enum GPT3: String, ModelID {

--- a/Sources/OpenAIKit/Model/Model.swift
+++ b/Sources/OpenAIKit/Model/Model.swift
@@ -45,6 +45,7 @@ extension Model {
 
     public enum GPT3: String, ModelID {
         case gpt3_5Turbo = "gpt-3.5-turbo"
+        case gpt3_5Turbo_1106 = "gpt-3.5-turbo-1106"
         case gpt3_5Turbo16K = "gpt-3.5-turbo-16k"
         case gpt3_5Turbo0301 = "gpt-3.5-turbo-0301"
         case textDavinci003 = "text-davinci-003"


### PR DESCRIPTION
GPT-4 Turbo (gpt-4-1106-preview) is an updated version of GPT-4 with 128K context that's currently being offered at 1/3 of the price per token of GPT-4. I'm going to start using it right away, and I figure it might be helpful for other people building apps on OpenAIKit. Also added gpt-3.5-turbo-1106, just so you can be extra specific and make sure you're as cost-efficient as possible.